### PR TITLE
Update package metadata before installing packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ if [[ $# -eq 0 ]] ; then
 fi
 
 # Install dependencies
+sudo apt-get update
 sudo apt-get install libudev-dev libusb-1.0
 sudo apt-get install -y gettext
 pip install -r requirements.txt


### PR DESCRIPTION
On Discord, @foamyguy mentioned that some builds were failing at the "install deps" step with a message like:
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10.33_amd64.deb  404  Not Found [IP: 52.177.174.250 80]
```
This kind of error can occur when the package metadata is out of date and this specific package version was superseded by another in a security update.

Ideally, the image supplied by github would always be up to date, but if it's not, then doing the "update" will ensure that the metadata is right at the cost of probably just 1-2s of runtime.

(I intended to submit this patch a few weeks ago but accidentally opened a PR against my fork instead, whoops!)