### PR TITLE
Apply SPDX copyright and license headers in compliance with REUSE.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md.license
+++ b/.github/PULL_REQUEST_TEMPLATE.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 Adafruit Industries
+
+SPDX-License-Identifier: MIT

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 name: Github CircuitPython Library CI
 
 on: [push]

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
 *.mpy
 .idea
 __pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: Unlicense
+
+repos:
+-   repo: https://github.com/fsfe/reuse-tool
+    rev: latest
+    hooks:
+    - id: reuse
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Adafruit for Adafruit Industries
+Copyright (c) 2019 Adafruit Industries
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSES/Unlicense.txt
+++ b/LICENSES/Unlicense.txt
@@ -1,0 +1,20 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+this software, either in source code form or as a compiled binary, for any
+purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and
+to the detriment of our heirs and successors. We intend this dedication to
+be an overt act of relinquishment in perpetuity of all present and future
+rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. For more information,
+please refer to <https://unlicense.org/>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Adafruit Industries
+
+SPDX-License-Identifier: MIT
+-->
+
 # Actions CI CircuitPython Init Script
 
 The purpose of this repo is to create a centrally managed dependency

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2019 Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 # we need bash 4 for associative arrays
 if [ "${BASH_VERSION%%[^0-9]*}" -lt "4" ]; then
   echo "BASH VERSION < 4: ${BASH_VERSION}" >&2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2019 Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense


### PR DESCRIPTION
The REUSE specifications[1] are meant to make it explicit and easier to
apply code licensing information for a project. The provided lint tool
makes it easy to ensure all the content (code and not code) is tagged.

Important notes:

 * All the code (and documentation) that otherwise didn't have an explicit
   license headers have been tagged with Kattni Rembor's copyright as per
   the LICENSE file.
 * All configuration files have been tagged with Kattni Rembor's copyright
   and Unlicense[2]. The current REUSE recommendation is to use CC0-1.0,
   but that has… side effects. There's some discussion in [3] about the
   recommendation for likely-uncopyrightable files (such as configuration
   files).

[1]: https://reuse.software/
[2]: https://unlicense.org/
[3]: https://github.com/fsfe/reuse-docs/issues/62