### PR TITLE
Install optional requirements if available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,6 @@ sudo apt-get install libudev-dev libusb-1.0
 sudo apt-get install -y gettext
 pip install -r requirements.txt
 if test -f "optional_requirements.txt"; then
-    python3 -m pip install -r optional_requirements.txt
+    pip install -r optional_requirements.txt
 fi
 pip install circuitpython-build-tools

--- a/install.sh
+++ b/install.sh
@@ -21,4 +21,7 @@ sudo apt-get update
 sudo apt-get install libudev-dev libusb-1.0
 sudo apt-get install -y gettext
 pip install -r requirements.txt
+if test -f "optional_requirements.txt"; then
+    python3 -m pip install -r optional_requirements.txt
+fi
 pip install circuitpython-build-tools


### PR DESCRIPTION
The plan for switching to `pyproject.toml` is use `optional_requirements.txt` to hold optional dependencies for libraries.  This may be an issue for things like building documentation and pylint, so this additional step checks for the file and pip installs it so.

While I don't think it would cause any issues if rolled out, this is totally fine as a draft PR until `pyproject.toml` gets rolled out, but wanted to get eyes on it early!