### PR TITLE
Check if library is correctly identified as module/package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,13 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/python/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+-   repo: https://github.com/pycqa/pylint
+    rev: v2.17.4
+    hooks:
+      - id: pylint
+        name: pylint
+        types: [python]

--- a/check_lib_packaging.py
+++ b/check_lib_packaging.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2023 Alec Delaney, for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Script for checking the packaging of libraries.
+
+Author(s): Alec Delaney, for Adafruit Industries
+"""
+
+import pathlib
+import sys
+import tomllib
+from collections.abc import Iterable
+
+with open("pyproject.toml", mode="rb") as tomlfile:
+    settings = tomllib.load(tomlfile)
+
+is_package = settings["tool"]["setuptools"].get("packages") is not None
+libnames: Iterable[str] = (
+    settings["tool"]["setuptools"]["packages"]
+    if is_package
+    else settings["tool"]["setuptools"]["py-modules"]
+)
+
+for libname in libnames:
+    library_path = pathlib.Path(libname)
+    if library_path.is_dir() != is_package:
+        REQUIRED_CHANGE = "package" if library_path.is_dir() else "module"
+        print(
+            f"Library {libname} should be specified as a {REQUIRED_CHANGE} in pyproject.toml!"
+        )
+        sys.exit(1)


### PR DESCRIPTION
Adds script for verifying packaging typing, Python-related pre-commit hooks