### PR TITLE
pin to python 3.11

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using semvers version range syntax.
+        python-version: '3.11' # Version range or exact version of a Python version to use, using semvers version range syntax.
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - name: pre-install
       run: |


### PR DESCRIPTION
I think this might be causing the actions failure here: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation/actions/runs/6711917226/job/18240352622

it's another manifestation of the python 3.12 issues if I am understanding correctly. Pinning to 3.11 here to match the other repos.